### PR TITLE
Using generic dependencies recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-gradle")
     implementation("org.openrewrite:rewrite-maven")
 
+    implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
 
     testImplementation("org.openrewrite:rewrite-java-17")

--- a/src/main/resources/META-INF/rewrite/cucumber.yml
+++ b/src/main/resources/META-INF/rewrite/cucumber.yml
@@ -93,7 +93,7 @@ tags:
   - cucumber
 recipeList:
   - org.openrewrite.cucumber.jvm.CucumberAnnotationToSuite
-  - org.openrewrite.maven.AddDependency:
+  - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.junit.platform
       artifactId: junit-platform-suite
       version: 1.9.x

--- a/src/main/resources/META-INF/rewrite/cucumber.yml
+++ b/src/main/resources/META-INF/rewrite/cucumber.yml
@@ -28,7 +28,7 @@ recipeList:
   - org.openrewrite.cucumber.jvm.DropSummaryPrinter
   - org.openrewrite.cucumber.jvm.RegexToCucumberExpression
   - org.openrewrite.cucumber.jvm.CucumberToJunitPlatformSuite
-  - org.openrewrite.maven.UpgradeDependencyVersion:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: io.cucumber
       artifactId: "*"
       newVersion: 7.x
@@ -54,12 +54,12 @@ tags:
   - testing
   - cucumber
 recipeList:
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: info.cukes
       oldArtifactId: cucumber-java
       newGroupId: io.cucumber
       newArtifactId: cucumber-java
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: info.cukes
       oldArtifactId: cucumber-java8
       newGroupId: io.cucumber
@@ -75,7 +75,7 @@ tags:
 recipeList:
   - org.openrewrite.cucumber.jvm.CucumberJava8HookDefinitionToCucumberJava
   - org.openrewrite.cucumber.jvm.CucumberJava8StepDefinitionToCucumberJava
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: io.cucumber
       oldArtifactId: cucumber-java8
       newGroupId: io.cucumber


### PR DESCRIPTION
## What's changed?
Using the new generic (maven/gradle) recipes to update/change dependencies instead of the maven specific ones.

## What's your motivation?
Since we have the generic ones, there is no reason to keep using the specific ones for maven. It's an easy fix and makes the recipe more useful for more projects.

## Anyone you would like to review specifically?
@timtebeek 
