### PR TITLE
refactor: Annotate methods which may return `null` with `@Nullable`

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
@@ -78,8 +78,9 @@ public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
     }
 
     static final class CucumberJava8HooksVisitor extends JavaVisitor<ExecutionContext> {
+
         @Override
-        public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+        public @Nullable J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
             J.MethodInvocation methodInvocation = (J.MethodInvocation) super.visitMethodInvocation(mi, ctx);
             if (!HOOK_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation) &&
                     !HOOK_NO_ARGS_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation)) {

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
@@ -66,8 +66,9 @@ public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
     }
 
     static final class CucumberStepDefinitionBodyVisitor extends JavaVisitor<ExecutionContext> {
+
         @Override
-        public J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+        public @Nullable J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(methodInvocation, ctx);
             if (!STEP_DEFINITION_METHOD_MATCHER.matches(m)) {
                 return m;


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.staticanalysis.AnnotateNullableMethods?organizationId=T3BlblJld3JpdGU%3D