### PR TITLE
Upgrade Cucumber-JVM 7.18.0 -> 7.34.4 to drop vulnerable shaded jackson-databind

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,10 @@ description = "Cucumber JVM Migration"
 
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
-    implementation("io.cucumber:cucumber-java:7.18.0")
-    implementation("io.cucumber:cucumber-java8:7.18.0")
-    implementation("io.cucumber:cucumber-plugin:7.18.0")
-    implementation("io.cucumber:cucumber-junit-platform-engine:7.18.0")
+    implementation("io.cucumber:cucumber-java:7.34.4")
+    implementation("io.cucumber:cucumber-java8:7.34.4")
+    implementation("io.cucumber:cucumber-plugin:7.34.4")
+    implementation("io.cucumber:cucumber-junit-platform-engine:7.34.4")
     implementation("org.junit.platform:junit-platform-suite-api:1.14.2")
 
     compileOnly("org.projectlombok:lombok:latest.release")


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1112

## What
Bumps the `io.cucumber:*` dependencies from **7.18.0** to **7.34.4** (latest).

## Why
The OWASP scan flags **jackson-databind 2.17.1** in this module (CVE-2026-54512 / CVE-2026-54513 HIGH, plus the moderate 54514/54515/54516/54517/54518). The vulnerable jackson was **shaded inside `cucumber-core-7.18.0.jar`**:

```
cucumber-core-7.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.17.1)
```

Because it is shaded into cucumber's own jar, a Gradle version constraint can't fix it — the vulnerable classes physically ship in the recipe artifact (that's why `jackson-databind` resolves to 2.21.4 on the classpath yet 2.17.1 is still reported). Every cucumber 7.19–7.33 still shades a vulnerable jackson (2.17.2 → 2.20.1, all in the CVE range). **cucumber-core 7.34.0+ removed the shaded jackson entirely** and now brings it as a normal transitive, so it resolves to **2.21.4** via rewrite-bom.

## Verification
- `./gradlew dependencyInsight --dependency jackson-databind` now shows only **2.21.4**; the shaded `cucumber-core-*.jar (shaded: jackson-databind:2.17.1)` entry is gone.
- `./gradlew build` passes — recipe code compiles and all tests pass against cucumber 7.34.4.
- All four artifacts (`cucumber-java`, `cucumber-java8`, `cucumber-plugin`, `cucumber-junit-platform-engine`) exist at 7.34.4; `junit-platform-suite-api` 1.14.2 already matches cucumber 7.34.4's JUnit 5.14.2.