### PR TITLE
Upgrade Cucumber dependencies to latest release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,11 @@ description = "Cucumber JVM Migration"
 
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
-    implementation("io.cucumber:cucumber-java:7.34.4")
-    implementation("io.cucumber:cucumber-java8:7.34.4")
-    implementation("io.cucumber:cucumber-plugin:7.34.4")
-    implementation("io.cucumber:cucumber-junit-platform-engine:7.34.4")
-    implementation("org.junit.platform:junit-platform-suite-api:1.14.2")
+    implementation("io.cucumber:cucumber-java:latest.release")
+    implementation("io.cucumber:cucumber-java8:latest.release")
+    implementation("io.cucumber:cucumber-plugin:latest.release")
+    implementation("io.cucumber:cucumber-junit-platform-engine:latest.release")
+    implementation("org.junit.platform:junit-platform-suite-api:latest.release")
 
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,8 @@ dependencies {
     implementation("io.cucumber:cucumber-java8:latest.release")
     implementation("io.cucumber:cucumber-plugin:latest.release")
     implementation("io.cucumber:cucumber-junit-platform-engine:latest.release")
-    implementation("org.junit.platform:junit-platform-suite-api:latest.release")
+    // JUnit Platform 6.x requires Java 17; recipe modules still compile against Java 8
+    implementation("org.junit.platform:junit-platform-suite-api:1.+")
 
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")


### PR DESCRIPTION
Updated Cucumber dependencies to use the latest release versions.

`org.junit.platform:junit-platform-suite-api` is deliberately kept on the `1.+` line instead: `latest.release` now resolves to 6.1.2, and JUnit Platform 6.x only publishes a JVM 17 variant, while recipe modules compile against Java 8. That broke `:compileClasspath` resolution:

```
> Could not resolve org.junit.platform:junit-platform-suite-api:latest.release.
  > Dependency resolution is looking for a library compatible with JVM runtime version 8,
    but 'org.junit.platform:junit-platform-suite-api:6.1.2' is only compatible with JVM runtime version 17 or newer.
```

With `1.+` it resolves to 1.14.4 (`org.gradle.jvm.version = 8`), matching the `junit-platform-engine` 1.14.x that `cucumber-junit-platform-engine` already brings in.