### PR TITLE
Inline named subclass visitors into `getVisitor()`

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberAnnotationToSuite.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberAnnotationToSuite.java
@@ -44,6 +44,9 @@ public class CucumberAnnotationToSuite extends Recipe {
     private static final String SUITE = "org.junit.platform.suite.api.Suite";
     private static final String SELECT_CLASSPATH_RESOURCE = "org.junit.platform.suite.api.SelectClasspathResource";
 
+    private static final AnnotationMatcher CUCUMBER_ANNOTATION_MATCHER = new AnnotationMatcher(
+            "@" + IO_CUCUMBER_JUNIT_PLATFORM_ENGINE_CUCUMBER);
+
     @Getter
     final String displayName = "Replace `@Cucumber` with `@Suite`";
 
@@ -57,42 +60,38 @@ public class CucumberAnnotationToSuite extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new UsesType<>(IO_CUCUMBER_JUNIT_PLATFORM_ENGINE_CUCUMBER, null),
-                new ExecutionContextJavaIsoVisitor());
-    }
+                new JavaIsoVisitor<ExecutionContext>() {
 
-    class ExecutionContextJavaIsoVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private final AnnotationMatcher cucumberAnnoMatcher = new AnnotationMatcher(
-                "@" + IO_CUCUMBER_JUNIT_PLATFORM_ENGINE_CUCUMBER);
+                    @Override
+                    @SneakyThrows
+                    public ClassDeclaration visitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx) {
+                        ClassDeclaration classDecl = super.visitClassDeclaration(cd, ctx);
+                        if (classDecl.getAllAnnotations().stream().noneMatch(CUCUMBER_ANNOTATION_MATCHER::matches)) {
+                            return classDecl;
+                        }
 
-        @Override
-        @SneakyThrows
-        public ClassDeclaration visitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx) {
-            ClassDeclaration classDecl = super.visitClassDeclaration(cd, ctx);
-            if (classDecl.getAllAnnotations().stream().noneMatch(cucumberAnnoMatcher::matches)) {
-                return classDecl;
-            }
+                        JavaParser.Builder javaParserSupplier = JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-platform-suite-api-1");
+                        JavaType.FullyQualified classFqn = TypeUtils.asFullyQualified(classDecl.getType());
+                        if (classFqn != null) {
+                            // Add suite annotation and select classpath resource
+                            JavaCoordinates coordinates = classDecl.getCoordinates().addAnnotation(Comparator.comparing(
+                                    J.Annotation::getSimpleName, new RuleBasedCollator("< SelectClasspathResource")));
+                            classDecl = JavaTemplate.builder("@Suite @SelectClasspathResource(\"#{}\")")
+                                    .contextSensitive()
+                                    .javaParser(javaParserSupplier)
+                                    .imports(SUITE, SELECT_CLASSPATH_RESOURCE)
+                                    .build()
+                                    .apply(getCursor(), coordinates, classFqn.getPackageName().replace('.', '/'));
+                            maybeAddImport(SUITE);
+                            maybeAddImport(SELECT_CLASSPATH_RESOURCE);
 
-            JavaParser.Builder javaParserSupplier = JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-platform-suite-api-1");
-            JavaType.FullyQualified classFqn = TypeUtils.asFullyQualified(classDecl.getType());
-            if (classFqn != null) {
-                // Add suite annotation and select classpath resource
-                JavaCoordinates coordinates = classDecl.getCoordinates().addAnnotation(Comparator.comparing(
-                        J.Annotation::getSimpleName, new RuleBasedCollator("< SelectClasspathResource")));
-                classDecl = JavaTemplate.builder("@Suite @SelectClasspathResource(\"#{}\")")
-                        .contextSensitive()
-                        .javaParser(javaParserSupplier)
-                        .imports(SUITE, SELECT_CLASSPATH_RESOURCE)
-                        .build()
-                        .apply(getCursor(), coordinates, classFqn.getPackageName().replace('.', '/'));
-                maybeAddImport(SUITE);
-                maybeAddImport(SELECT_CLASSPATH_RESOURCE);
-
-                // Remove cucumber annotation
-                classDecl = classDecl.withLeadingAnnotations(ListUtils.map(classDecl.getLeadingAnnotations(),
-                        ann -> cucumberAnnoMatcher.matches(ann) ? null : ann));
-                maybeRemoveImport(IO_CUCUMBER_JUNIT_PLATFORM_ENGINE_CUCUMBER);
-            }
-            return classDecl;
-        }
+                            // Remove cucumber annotation
+                            classDecl = classDecl.withLeadingAnnotations(ListUtils.map(classDecl.getLeadingAnnotations(),
+                                    ann -> CUCUMBER_ANNOTATION_MATCHER.matches(ann) ? null : ann));
+                            maybeRemoveImport(IO_CUCUMBER_JUNIT_PLATFORM_ENGINE_CUCUMBER);
+                        }
+                        return classDecl;
+                    }
+                });
     }
 }

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
@@ -65,76 +65,74 @@ public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
                 Preconditions.or(
                         new UsesMethod<>(HOOK_BODY_DEFINITION, true),
                         new UsesMethod<>(HOOK_NO_ARGS_BODY_DEFINITION, true))
-                , new CucumberJava8HooksVisitor());
+                , new JavaVisitor<ExecutionContext>() {
+
+                    @Override
+                    public @Nullable J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                        J.MethodInvocation methodInvocation = (J.MethodInvocation) super.visitMethodInvocation(mi, ctx);
+                        if (!HOOK_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation) &&
+                                !HOOK_NO_ARGS_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation)) {
+                            return methodInvocation;
+                        }
+
+                        // Replacement annotations can only handle literals or constants
+                        if (methodInvocation.getArguments().stream()
+                                .anyMatch(arg -> !(arg instanceof J.Literal) && !(arg instanceof J.Lambda))) {
+                            return SearchResult.found(methodInvocation, "TODO Migrate manually");
+                        }
+
+                        // Extract arguments passed to method
+                        HookArguments hookArguments = parseHookArguments(methodInvocation.getSimpleName(),
+                                methodInvocation.getArguments());
+
+                        // Add new template method at end of class declaration
+                        J.ClassDeclaration parentClass = getCursor()
+                                .dropParentUntil(J.ClassDeclaration.class::isInstance)
+                                .getValue();
+                        doAfterVisit(new CucumberJava8ClassVisitor(
+                                parentClass.getType(),
+                                hookArguments.replacementImport(),
+                                hookArguments.template(),
+                                hookArguments.parameters()));
+
+                        // Remove original method invocation; it's replaced in the above
+                        // visitor
+                        // noinspection DataFlowIssue
+                        return null;
+                    }
+                });
     }
 
-    static final class CucumberJava8HooksVisitor extends JavaVisitor<ExecutionContext> {
-
-        @Override
-        public @Nullable J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-            J.MethodInvocation methodInvocation = (J.MethodInvocation) super.visitMethodInvocation(mi, ctx);
-            if (!HOOK_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation) &&
-                    !HOOK_NO_ARGS_BODY_DEFINITION_METHOD_MATCHER.matches(methodInvocation)) {
-                return methodInvocation;
-            }
-
-            // Replacement annotations can only handle literals or constants
-            if (methodInvocation.getArguments().stream()
-                    .anyMatch(arg -> !(arg instanceof J.Literal) && !(arg instanceof J.Lambda))) {
-                return SearchResult.found(methodInvocation, "TODO Migrate manually");
-            }
-
-            // Extract arguments passed to method
-            HookArguments hookArguments = parseHookArguments(methodInvocation.getSimpleName(),
-                    methodInvocation.getArguments());
-
-            // Add new template method at end of class declaration
-            J.ClassDeclaration parentClass = getCursor()
-                    .dropParentUntil(J.ClassDeclaration.class::isInstance)
-                    .getValue();
-            doAfterVisit(new CucumberJava8ClassVisitor(
-                    parentClass.getType(),
-                    hookArguments.replacementImport(),
-                    hookArguments.template(),
-                    hookArguments.parameters()));
-
-            // Remove original method invocation; it's replaced in the above
-            // visitor
-            // noinspection DataFlowIssue
-            return null;
+    /**
+     * Parse up to three arguments: - last one is always a Lambda; - first
+     * can also be a String or int. - second can be an int;
+     */
+    private static HookArguments parseHookArguments(String methodName, List<Expression> arguments) {
+        // Lambda is always last, and can either contain a body with
+        // Scenario argument, or without
+        int argumentsSize = arguments.size();
+        Expression lambdaArgument = arguments.get(argumentsSize - 1);
+        HookArguments hookArguments = new HookArguments(
+                methodName,
+                null,
+                null,
+                (J.Lambda) lambdaArgument);
+        if (argumentsSize == 1) {
+            return hookArguments;
         }
 
-        /**
-         * Parse up to three arguments: - last one is always a Lambda; - first
-         * can also be a String or int. - second can be an int;
-         */
-        HookArguments parseHookArguments(String methodName, List<Expression> arguments) {
-            // Lambda is always last, and can either contain a body with
-            // Scenario argument, or without
-            int argumentsSize = arguments.size();
-            Expression lambdaArgument = arguments.get(argumentsSize - 1);
-            HookArguments hookArguments = new HookArguments(
-                    methodName,
-                    null,
-                    null,
-                    (J.Lambda) lambdaArgument);
-            if (argumentsSize == 1) {
-                return hookArguments;
+        J.Literal firstArgument = (J.Literal) arguments.get(0);
+        if (argumentsSize == 2) {
+            // First argument is either a String or an int
+            if (firstArgument.getType() == Primitive.String) {
+                return hookArguments.withTagExpression((String) firstArgument.getValue());
             }
-
-            J.Literal firstArgument = (J.Literal) arguments.get(0);
-            if (argumentsSize == 2) {
-                // First argument is either a String or an int
-                if (firstArgument.getType() == Primitive.String) {
-                    return hookArguments.withTagExpression((String) firstArgument.getValue());
-                }
-                return hookArguments.withOrder((Integer) firstArgument.getValue());
-            }
-            // First argument is always a String, second argument always an int
-            return hookArguments
-                    .withTagExpression((String) firstArgument.getValue())
-                    .withOrder((Integer) ((J.Literal) arguments.get(1)).getValue());
+            return hookArguments.withOrder((Integer) firstArgument.getValue());
         }
+        // First argument is always a String, second argument always an int
+        return hookArguments
+                .withTagExpression((String) firstArgument.getValue())
+                .withOrder((Integer) ((J.Literal) arguments.get(1)).getValue());
     }
 
 }

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
@@ -54,71 +54,69 @@ public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new UsesMethod<>(IO_CUCUMBER_JAVA8_STEP_DEFINITION, true),
-                new CucumberStepDefinitionBodyVisitor());
-    }
+                new JavaVisitor<ExecutionContext>() {
 
-    static final class CucumberStepDefinitionBodyVisitor extends JavaVisitor<ExecutionContext> {
+                    @Override
+                    public @Nullable J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+                        J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(methodInvocation, ctx);
+                        if (!STEP_DEFINITION_METHOD_MATCHER.matches(m)) {
+                            return m;
+                        }
 
-        @Override
-        public @Nullable J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
-            J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(methodInvocation, ctx);
-            if (!STEP_DEFINITION_METHOD_MATCHER.matches(m)) {
-                return m;
-            }
+                        // Skip any methods not containing a second argument, such as
+                        // Scenario.log(String)
+                        List<Expression> arguments = m.getArguments();
+                        if (arguments.size() < 2) {
+                            return m;
+                        }
 
-            // Skip any methods not containing a second argument, such as
-            // Scenario.log(String)
-            List<Expression> arguments = m.getArguments();
-            if (arguments.size() < 2) {
-                return m;
-            }
+                        // Annotations require a String literal
+                        Expression stringExpression = arguments.get(0);
+                        if (!(stringExpression instanceof J.Literal)) {
+                            return SearchResult.found(m, "TODO Migrate manually");
+                        }
+                        J.Literal literal = (J.Literal) stringExpression;
 
-            // Annotations require a String literal
-            Expression stringExpression = arguments.get(0);
-            if (!(stringExpression instanceof J.Literal)) {
-                return SearchResult.found(m, "TODO Migrate manually");
-            }
-            J.Literal literal = (J.Literal) stringExpression;
+                        // Extract step definition body, when applicable
+                        Expression possibleStepDefinitionBody = arguments.get(1); // Always
+                        // available
+                        // after a
+                        // first
+                        // String
+                        // argument
+                        if (!(possibleStepDefinitionBody instanceof J.Lambda) ||
+                                !TypeUtils.isAssignableTo(IO_CUCUMBER_JAVA8_STEP_DEFINITION_BODY,
+                                        possibleStepDefinitionBody.getType())) {
+                            return SearchResult.found(m, "TODO Migrate manually");
+                        }
+                        J.Lambda lambda = (J.Lambda) possibleStepDefinitionBody;
 
-            // Extract step definition body, when applicable
-            Expression possibleStepDefinitionBody = arguments.get(1); // Always
-            // available
-            // after a
-            // first
-            // String
-            // argument
-            if (!(possibleStepDefinitionBody instanceof J.Lambda) ||
-                    !TypeUtils.isAssignableTo(IO_CUCUMBER_JAVA8_STEP_DEFINITION_BODY,
-                    possibleStepDefinitionBody.getType())) {
-                return SearchResult.found(m, "TODO Migrate manually");
-            }
-            J.Lambda lambda = (J.Lambda) possibleStepDefinitionBody;
+                        StepDefinitionArguments stepArguments = new StepDefinitionArguments(
+                                m.getSimpleName(), literal, lambda);
 
-            StepDefinitionArguments stepArguments = new StepDefinitionArguments(
-                    m.getSimpleName(), literal, lambda);
+                        // Determine step definitions class name
+                        J.ClassDeclaration parentClass = getCursor()
+                                .dropParentUntil(J.ClassDeclaration.class::isInstance)
+                                .getValue();
+                        if (m.getMethodType() == null) {
+                            return m;
+                        }
+                        String replacementImport = String.format("%s.%s",
+                                m.getMethodType().getDeclaringType().getFullyQualifiedName()
+                                        .replace("java8", "java").toLowerCase(),
+                                m.getSimpleName());
+                        doAfterVisit(new CucumberJava8ClassVisitor(
+                                parentClass.getType(),
+                                replacementImport,
+                                stepArguments.template(),
+                                stepArguments.parameters()));
 
-            // Determine step definitions class name
-            J.ClassDeclaration parentClass = getCursor()
-                    .dropParentUntil(J.ClassDeclaration.class::isInstance)
-                    .getValue();
-            if (m.getMethodType() == null) {
-                return m;
-            }
-            String replacementImport = String.format("%s.%s",
-                    m.getMethodType().getDeclaringType().getFullyQualifiedName()
-                            .replace("java8", "java").toLowerCase(),
-                    m.getSimpleName());
-            doAfterVisit(new CucumberJava8ClassVisitor(
-                    parentClass.getType(),
-                    replacementImport,
-                    stepArguments.template(),
-                    stepArguments.parameters()));
-
-            // Remove original method invocation; it's replaced in the above
-            // visitor
-            // noinspection DataFlowIssue
-            return null;
-        }
+                        // Remove original method invocation; it's replaced in the above
+                        // visitor
+                        // noinspection DataFlowIssue
+                        return null;
+                    }
+                });
     }
 
 }

--- a/src/main/java/org/openrewrite/cucumber/jvm/DropSummaryPrinter.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/DropSummaryPrinter.java
@@ -49,38 +49,37 @@ public class DropSummaryPrinter extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER, null), new DropSummaryPrinterVisitor());
-    }
+        return Preconditions.check(new UsesType<>(IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER, null), new JavaIsoVisitor<ExecutionContext>() {
 
-    static final class DropSummaryPrinterVisitor extends JavaIsoVisitor<ExecutionContext> {
-        @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration cd, ExecutionContext ctx) {
-            J.ClassDeclaration classDeclaration = super.visitClassDeclaration(cd, ctx);
-            boolean implementsSummaryPrinter = Stream.of(classDeclaration.getImplements())
-                    .filter(Objects::nonNull)
-                    .flatMap(Collection::stream)
-                    .anyMatch(t -> TypeUtils.isOfClassType(t.getType(), IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER));
-            boolean alreadyImplementsPlugin = Stream.of(classDeclaration.getImplements())
-                    .filter(Objects::nonNull)
-                    .flatMap(Collection::stream)
-                    .anyMatch(t -> TypeUtils.isOfClassType(t.getType(), IO_CUCUMBER_PLUGIN_PLUGIN));
-            if (!implementsSummaryPrinter) {
-                return classDeclaration;
-            }
-            doAfterVisit(new ChangeType(
-                    IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER,
-                    IO_CUCUMBER_PLUGIN_PLUGIN,
-                    true).getVisitor());
-            doAfterVisit(new RemoveImport<>(IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER));
-            return classDeclaration.withImplements(ListUtils.map(classDeclaration.getImplements(), i -> {
-                // Remove duplicate implements
-                if (TypeUtils.isOfClassType(i.getType(), IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER) &&
-                        alreadyImplementsPlugin) {
-                    return null;
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration cd, ExecutionContext ctx) {
+                J.ClassDeclaration classDeclaration = super.visitClassDeclaration(cd, ctx);
+                boolean implementsSummaryPrinter = Stream.of(classDeclaration.getImplements())
+                        .filter(Objects::nonNull)
+                        .flatMap(Collection::stream)
+                        .anyMatch(t -> TypeUtils.isOfClassType(t.getType(), IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER));
+                boolean alreadyImplementsPlugin = Stream.of(classDeclaration.getImplements())
+                        .filter(Objects::nonNull)
+                        .flatMap(Collection::stream)
+                        .anyMatch(t -> TypeUtils.isOfClassType(t.getType(), IO_CUCUMBER_PLUGIN_PLUGIN));
+                if (!implementsSummaryPrinter) {
+                    return classDeclaration;
                 }
-                return i;
-            }));
-        }
+                doAfterVisit(new ChangeType(
+                        IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER,
+                        IO_CUCUMBER_PLUGIN_PLUGIN,
+                        true).getVisitor());
+                doAfterVisit(new RemoveImport<>(IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER));
+                return classDeclaration.withImplements(ListUtils.map(classDeclaration.getImplements(), i -> {
+                    // Remove duplicate implements
+                    if (TypeUtils.isOfClassType(i.getType(), IO_CUCUMBER_PLUGIN_SUMMARY_PRINTER) &&
+                            alreadyImplementsPlugin) {
+                        return null;
+                    }
+                    return i;
+                }));
+            }
+        });
     }
 
 }

--- a/src/main/java/org/openrewrite/cucumber/jvm/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/RegexToCucumberExpression.java
@@ -51,89 +51,86 @@ public class RegexToCucumberExpression extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(IO_CUCUMBER_JAVA_STEP_DEFINITION, null), new CucumberStepDefinitionBodyVisitor());
+        return Preconditions.check(new UsesType<>(IO_CUCUMBER_JAVA_STEP_DEFINITION, null), new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration m, ExecutionContext ctx) {
+                J.MethodDeclaration methodDeclaration = super.visitMethodDeclaration(m, ctx);
+                return methodDeclaration.withLeadingAnnotations(ListUtils.map(methodDeclaration.getLeadingAnnotations(),
+                        ann -> replaceRegexWithCucumberExpression(methodDeclaration, ann)));
+            }
+        });
     }
 
-    static final class CucumberStepDefinitionBodyVisitor extends JavaIsoVisitor<ExecutionContext> {
-
-        @Override
-        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration m, ExecutionContext ctx) {
-            J.MethodDeclaration methodDeclaration = super.visitMethodDeclaration(m, ctx);
-            return methodDeclaration.withLeadingAnnotations(ListUtils.map(methodDeclaration.getLeadingAnnotations(),
-                    ann -> replaceRegexWithCucumberExpression(methodDeclaration, ann)));
+    private static J.Annotation replaceRegexWithCucumberExpression(
+            // For when we want to match regexes with method arguments for
+            // replacement cucumber expressions
+            // https://github.com/cucumber/cucumber-expressions#parameter-types
+            J.MethodDeclaration methodDeclaration,
+            J.Annotation annotation
+    ) {
+        // Skip if not a cucumber annotation
+        JavaType.FullyQualified annoFqn = TypeUtils.asFullyQualified(annotation.getType());
+        if (annoFqn == null || !annoFqn.getPackageName().startsWith(IO_CUCUMBER_JAVA)) {
+            return annotation;
         }
 
-        private static J.Annotation replaceRegexWithCucumberExpression(
-                // For when we want to match regexes with method arguments for
-                // replacement cucumber expressions
-                // https://github.com/cucumber/cucumber-expressions#parameter-types
-                J.MethodDeclaration methodDeclaration,
-                J.Annotation annotation
-        ) {
-
-            // Skip if not a cucumber annotation
-            JavaType.FullyQualified annoFqn = TypeUtils.asFullyQualified(annotation.getType());
-            if (annoFqn == null || !annoFqn.getPackageName().startsWith(IO_CUCUMBER_JAVA)) {
-                return annotation;
-            }
-
-            List<Expression> arguments = annotation.getArguments();
-            Optional<String> possibleExpression = Stream.of(arguments)
-                    .filter(Objects::nonNull)
-                    .filter(list -> list.size() == 1)
-                    .flatMap(Collection::stream)
-                    .filter(J.Literal.class::isInstance)
-                    .map(org.openrewrite.java.tree.J.Literal.class::cast)
-                    .map(l -> (String) l.getValue())
-                    // https://github.com/cucumber/cucumber-expressions/blob/main/java/heuristics.adoc
-                    .filter(s -> s != null && (s.startsWith("^") || s.endsWith("$") || leadingAndTrailingSlash(s)))
-                    .findFirst();
-            if (!possibleExpression.isPresent()) {
-                return annotation;
-            }
-
-            // Strip leading/trailing regex anchors
-            String replacement = stripAnchors(possibleExpression.get());
-
-            // Back off when special characters are encountered in regex
-            if (Stream.of("(", ")", "{", "}", "[", "]", "?", "*", "+", "/", "\\", "^", "|")
-                    .anyMatch(replacement::contains)) {
-                return annotation;
-            }
-
-            // Replace regular expression with cucumber expression
-            final String finalReplacement = String.format("\"%s\"", replacement);
-            return annotation.withArguments(ListUtils.map(annotation.getArguments(), arg -> ((J.Literal) arg)
-                    .withValue(finalReplacement)
-                    .withValueSource(finalReplacement)));
+        List<Expression> arguments = annotation.getArguments();
+        Optional<String> possibleExpression = Stream.of(arguments)
+                .filter(Objects::nonNull)
+                .filter(list -> list.size() == 1)
+                .flatMap(Collection::stream)
+                .filter(J.Literal.class::isInstance)
+                .map(J.Literal.class::cast)
+                .map(l -> (String) l.getValue())
+                // https://github.com/cucumber/cucumber-expressions/blob/main/java/heuristics.adoc
+                .filter(s -> s != null && (s.startsWith("^") || s.endsWith("$") || leadingAndTrailingSlash(s)))
+                .findFirst();
+        if (!possibleExpression.isPresent()) {
+            return annotation;
         }
 
-        private static String stripAnchors(final String initialExpression) {
-            if (leadingAndTrailingSlash(initialExpression)) {
-                return initialExpression.substring(1, initialExpression.length() - 1);
-            }
+        // Strip leading/trailing regex anchors
+        String replacement = stripAnchors(possibleExpression.get());
 
-            // The presence of anchors assumes a Regular Expression, even if
-            // only one of the anchors are present
-            String replacement = initialExpression;
-            if (replacement.startsWith("^")) {
-                replacement = replacement.substring(1);
-            }
-            if (replacement.endsWith("$")) {
-                replacement = replacement.substring(0, replacement.length() - 1);
-            }
-
-            // Prevent conversion of `^/hello world/$` to `/hello world/`
-            if (leadingAndTrailingSlash(replacement)) {
-                return initialExpression;
-            }
-
-            return replacement;
+        // Back off when special characters are encountered in regex
+        if (Stream.of("(", ")", "{", "}", "[", "]", "?", "*", "+", "/", "\\", "^", "|")
+                .anyMatch(replacement::contains)) {
+            return annotation;
         }
 
-        private static boolean leadingAndTrailingSlash(final String initialExpression) {
-            return initialExpression.startsWith("/") && initialExpression.endsWith("/");
+        // Replace regular expression with cucumber expression
+        final String finalReplacement = String.format("\"%s\"", replacement);
+        return annotation.withArguments(ListUtils.map(annotation.getArguments(), arg -> ((J.Literal) arg)
+                .withValue(finalReplacement)
+                .withValueSource(finalReplacement)));
+    }
+
+    private static String stripAnchors(final String initialExpression) {
+        if (leadingAndTrailingSlash(initialExpression)) {
+            return initialExpression.substring(1, initialExpression.length() - 1);
         }
+
+        // The presence of anchors assumes a Regular Expression, even if
+        // only one of the anchors are present
+        String replacement = initialExpression;
+        if (replacement.startsWith("^")) {
+            replacement = replacement.substring(1);
+        }
+        if (replacement.endsWith("$")) {
+            replacement = replacement.substring(0, replacement.length() - 1);
+        }
+
+        // Prevent conversion of `^/hello world/$` to `/hello world/`
+        if (leadingAndTrailingSlash(replacement)) {
+            return initialExpression;
+        }
+
+        return replacement;
+    }
+
+    private static boolean leadingAndTrailingSlash(final String initialExpression) {
+        return initialExpression.startsWith("/") && initialExpression.endsWith("/");
     }
 
 }


### PR DESCRIPTION
This module used the older convention of declaring each recipe's visitor as a separate named subclass; those are now inlined as anonymous visitors returned directly from `getVisitor()`. Affects `CucumberAnnotationToSuite`, `DropSummaryPrinter`, `RegexToCucumberExpression`, `CucumberJava8StepDefinitionToCucumberJava`, and `CucumberJava8HookDefinitionToCucumberJava`.

Because this module compiles at Java 8, where anonymous classes cannot declare static members, the visitors' static helpers (`replaceRegexWithCucumberExpression`, `stripAnchors`, `leadingAndTrailingSlash`, `parseHookArguments`) moved up to their enclosing recipe classes, and the `AnnotationMatcher` field in `CucumberAnnotationToSuite` became a static constant.

`CucumberJava8ClassVisitor` was left as-is, since it is a parameterized visitor shared by both java8 recipes via `doAfterVisit` rather than a per-recipe visitor subclass. Behavior is unchanged and the existing test suite passes.