### PR TITLE
DO NOT MERGE — canary for gh-automation#104 (Gradle build cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@tim/canary-enable-gradle-build-cache
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
Throwaway canary. **Do not merge; do not review.** Will be closed once measurements are collected.

- Points `ci.yml` at `openrewrite/gh-automation@tim/canary-enable-gradle-build-cache`, which carries the `--build-cache` change from openrewrite/gh-automation#104 with the composite-action refs pinned to itself (otherwise the inner `actions/build@main` refs would resolve back to `main` and the canary would test nothing).

Purpose: exercise the Develocity **remote** build cache, which local validation could not reach.

Expect **run 1 to show no cache hits** — nothing populates the remote cache today, so this run seeds it. The measurement comes from a second run on the same tree.