### PR TITLE
Only remove the step definitions class' own empty constructor

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
@@ -64,12 +64,22 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
             @Override
             public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
                 J.MethodDeclaration methodDeclaration = super.visitMethodDeclaration(md, ctx);
-                if (methodDeclaration.isConstructor() && (methodDeclaration.getBody() == null ||
-                        methodDeclaration.getBody().getStatements().isEmpty())) {
+                if (methodDeclaration.isConstructor() && isStepDefinitionsClassMember() &&
+                        (methodDeclaration.getBody() == null ||
+                                methodDeclaration.getBody().getStatements().isEmpty())) {
                     // noinspection DataFlowIssue
                     return null;
                 }
                 return methodDeclaration;
+            }
+
+            /**
+             * This visitor runs over the whole source file, which can hold classes other than the one being
+             * migrated; only the step definitions class has a constructor left empty by this recipe.
+             */
+            private boolean isStepDefinitionsClassMember() {
+                J.ClassDeclaration enclosing = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                return enclosing != null && TypeUtils.isOfType(enclosing.getType(), stepDefinitionsClass);
             }
         });
 

--- a/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
+++ b/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
@@ -208,6 +208,73 @@ class CucumberJava8ToCucumberJavaTest implements RewriteTest {
                 17));
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-cucumber-jvm/issues/47")
+        @SuppressWarnings("CodeBlock2Expr")
+        @Test
+        void retainEmptyConstructorsOfOtherClasses() {
+            rewriteRun(
+              version(
+                // language=java
+                java(
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java8.En;
+
+                    public class CalculatorStepDefinitions implements En {
+                        public CalculatorStepDefinitions() {
+                            Given("a calculator I just turned on", () -> {
+                            });
+                        }
+
+                        static class Money {
+                            private int amount;
+
+                            Money(int amount) {
+                                this.amount = amount;
+                            }
+
+                            Money() {
+                            }
+                        }
+                    }
+
+                    class Helper {
+                        Helper() {
+                        }
+                    }
+                    """,
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CalculatorStepDefinitions {
+
+                        @Given("a calculator I just turned on")
+                        public void a_calculator_i_just_turned_on() {
+                        }
+
+                        static class Money {
+                            private int amount;
+
+                            Money(int amount) {
+                                this.amount = amount;
+                            }
+
+                            Money() {
+                            }
+                        }
+                    }
+
+                    class Helper {
+                        Helper() {
+                        }
+                    }
+                    """),
+                17));
+        }
+
         @SuppressWarnings("CodeBlock2Expr")
         @Test
         void methodInvocationsOutsideConstructor() {


### PR DESCRIPTION
- Picks up the second box from #47.

`CucumberJava8ClassVisitor` hoists each lambda out of the glue constructor and then removes that constructor once it is empty. The cleanup was scheduled with `doAfterVisit`, which runs over the **whole compilation unit** rather than the class being migrated, so it removed *any* no-arg constructor with an empty body in the same file:

```java
public class CtorSteps implements En {
    public CtorSteps() { Given("I have {int} cukes", (Integer n) -> { }); }

    public static class Money {
        private int amount;
        public Money(int amount) { this.amount = amount; }
        public Money() { }                      // <-- removed
    }
}

class Helper {
    Helper() { }                                // <-- removed
    Helper(String name) { this.name = name; }
}
```

Both of those are public API this recipe never touched, and their removal breaks every `new Money()` / `new Helper()` caller — silently, with no `TODO Migrate manually` marker. A file that compiled cleanly beforehand no longer does.

The removal is now gated on the constructor's enclosing class being the step definitions class the visitor was constructed for, which is the only class whose constructor this recipe empties.

Verified the new test fails on `main` and passes with the change.