### PR TITLE
Retain constructor injected dependencies when migrating `cucumber-java8`

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
@@ -26,8 +26,10 @@ import org.openrewrite.staticanalysis.RemoveUnneededBlock;
 import org.openrewrite.staticanalysis.UnnecessaryThrows;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 
@@ -109,6 +111,7 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
         if (constructor == null) {
             return classDeclaration;
         }
+        Set<String> namesTaken = declaredFieldNames(classDeclaration);
         StringBuilder fields = new StringBuilder();
         StringBuilder assignments = new StringBuilder();
         for (Statement parameter : constructor.getParameters()) {
@@ -120,8 +123,8 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
                 continue;
             }
             String name = argument.getVariables().get(0).getSimpleName();
-            if (declaresField(classDeclaration, name)) {
-                // Already retained, on an earlier pass over this same class
+            if (!namesTaken.add(name)) {
+                // Already retained on an earlier pass over this same class, or taken by a field declared here
                 continue;
             }
             fields.append(String.format("private final %s %s;%n",
@@ -166,17 +169,16 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
                 .noneMatch(J.VariableDeclarations.class::isInstance) ? null : constructor;
     }
 
-    private static boolean declaresField(J.ClassDeclaration classDeclaration, String name) {
+    private static Set<String> declaredFieldNames(J.ClassDeclaration classDeclaration) {
+        Set<String> names = new HashSet<>();
         for (Statement statement : classDeclaration.getBody().getStatements()) {
             if (statement instanceof J.VariableDeclarations) {
                 for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) statement).getVariables()) {
-                    if (name.equals(variable.getSimpleName())) {
-                        return true;
-                    }
+                    names.add(variable.getSimpleName());
                 }
             }
         }
-        return false;
+        return names;
     }
 
     /**

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
@@ -86,7 +86,87 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
                         JavaParser.fromJavaVersion().classpathFromResources(ctx, "cucumber-java-7", "cucumber-java8-7"))
                 .imports(replacementImport)
                 .build().apply(getCursor(), coordinatesForNewMethod(classDeclaration.getBody()), templateParameters);
-        return applied.withImplements(retained);
+        return retainConstructorArguments(applied.withImplements(retained));
+    }
+
+    /**
+     * The lambdas moved out of the constructor commonly close over its arguments, which is how `cucumber-java8`
+     * glue receives its dependency injected collaborators. Those arguments are out of scope in the methods the
+     * lambda bodies now live in, so hold each one in a field that the constructor assigns.
+     */
+    private J.ClassDeclaration retainConstructorArguments(J.ClassDeclaration classDeclaration) {
+        J.MethodDeclaration constructor = soleConstructor(classDeclaration);
+        if (constructor == null) {
+            return classDeclaration;
+        }
+        StringBuilder fields = new StringBuilder();
+        StringBuilder assignments = new StringBuilder();
+        for (Statement parameter : constructor.getParameters()) {
+            if (!(parameter instanceof J.VariableDeclarations)) {
+                continue;
+            }
+            J.VariableDeclarations argument = (J.VariableDeclarations) parameter;
+            if (argument.getTypeExpression() == null || argument.getVariables().size() != 1) {
+                continue;
+            }
+            String name = argument.getVariables().get(0).getSimpleName();
+            if (declaresField(classDeclaration, name)) {
+                // Already retained, on an earlier pass over this same class
+                continue;
+            }
+            fields.append(String.format("private final %s %s;%n",
+                    argument.getTypeExpression().printTrimmed(getCursor()), name));
+            assignments.append(String.format("this.%s = %s;%n", name, name));
+        }
+        if (fields.length() == 0) {
+            return classDeclaration;
+        }
+
+        J.ClassDeclaration c = JavaTemplate.builder(fields.toString())
+                .contextSensitive()
+                .build()
+                .apply(updateCursor(classDeclaration), classDeclaration.getBody().getCoordinates().firstStatement());
+        J.MethodDeclaration reboundConstructor = soleConstructor(c);
+        if (reboundConstructor == null || reboundConstructor.getBody() == null) {
+            return c;
+        }
+        // Appended rather than prepended, as `firstStatement` anchors on a statement that may since have been
+        // replaced, and has nothing to anchor to at all once the lambdas have left the constructor empty
+        return JavaTemplate.builder(assignments.toString())
+                .contextSensitive()
+                .build()
+                .apply(updateCursor(c), reboundConstructor.getBody().getCoordinates().lastStatement());
+    }
+
+    /**
+     * @return the only constructor of the class, if it takes arguments; {@code null} when there is no such
+     * constructor, or more than one, as then there is no single place to assign the fields from
+     */
+    private static J.@Nullable MethodDeclaration soleConstructor(J.ClassDeclaration classDeclaration) {
+        J.MethodDeclaration constructor = null;
+        for (Statement statement : classDeclaration.getBody().getStatements()) {
+            if (statement instanceof J.MethodDeclaration && ((J.MethodDeclaration) statement).isConstructor()) {
+                if (constructor != null) {
+                    return null;
+                }
+                constructor = (J.MethodDeclaration) statement;
+            }
+        }
+        return constructor == null || constructor.getParameters().stream()
+                .noneMatch(J.VariableDeclarations.class::isInstance) ? null : constructor;
+    }
+
+    private static boolean declaresField(J.ClassDeclaration classDeclaration, String name) {
+        for (Statement statement : classDeclaration.getBody().getStatements()) {
+            if (statement instanceof J.VariableDeclarations) {
+                for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) statement).getVariables()) {
+                    if (name.equals(variable.getSimpleName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
+++ b/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
@@ -208,6 +208,82 @@ class CucumberJava8ToCucumberJavaTest implements RewriteTest {
                 17));
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-cucumber-jvm/issues/47")
+        @SuppressWarnings("CodeBlock2Expr")
+        @Test
+        void retainConstructorInjectedDependencies() {
+            rewriteRun(
+              version(
+                // language=java
+                java(
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java8.En;
+
+                    public class CalculatorStepDefinitions implements En {
+
+                        public CalculatorStepDefinitions(RpnCalculator calc, Log log) {
+                            Given("a calculator I just turned on", () -> {
+                                calc.push(0);
+                            });
+
+                            Then("the result is {double}", (Double expected) -> {
+                                log.record(expected);
+                            });
+                        }
+
+                        static class RpnCalculator {
+                            void push(Object o) {
+                            }
+                        }
+
+                        static class Log {
+                            void record(Object o) {
+                            }
+                        }
+                    }
+                    """,
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+                    import io.cucumber.java.en.Then;
+
+                    public class CalculatorStepDefinitions {
+
+                        private final RpnCalculator calc;
+                        private final Log log;
+
+                        public CalculatorStepDefinitions(RpnCalculator calc, Log log) {
+                            this.calc = calc;
+                            this.log = log;
+                        }
+
+                        @Given("a calculator I just turned on")
+                        public void a_calculator_i_just_turned_on() {
+                            calc.push(0);
+                        }
+
+                        @Then("the result is {double}")
+                        public void the_result_is_double(Double expected) {
+                            log.record(expected);
+                        }
+
+                        static class RpnCalculator {
+                            void push(Object o) {
+                            }
+                        }
+
+                        static class Log {
+                            void record(Object o) {
+                            }
+                        }
+                    }
+                    """),
+                17));
+        }
+
         @SuppressWarnings("CodeBlock2Expr")
         @Test
         void methodInvocationsOutsideConstructor() {

--- a/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
+++ b/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
@@ -351,7 +351,6 @@ class CucumberJava8ToCucumberJavaTest implements RewriteTest {
                 17));
         }
 
-
         @SuppressWarnings("CodeBlock2Expr")
         @Test
         void methodInvocationsOutsideConstructor() {


### PR DESCRIPTION
- Picks up the first box from #47, the one that hit every `cucumber-java8` project I validated against.

`CucumberJava8ClassVisitor` hoists each lambda into a method and then drops the glue constructor once it is empty. But those lambdas commonly close over the constructor's **arguments** — which is how `cucumber-java8` glue receives its dependency injected collaborators under picocontainer, cucumber-spring or guice. The arguments are out of scope in the methods the lambda bodies now live in, so the migrated class does not compile, and the constructor carrying the injection points is gone too:

```java
// before                                        // after
public class Steps implements En {               public class Steps {
    public Steps(MockMvc mockMvc, Context ctx) {
        When("...", () -> {                          @When("...")
            mockMvc.perform(...);                    public void ...() throws Exception {
            ctx.setMvcResult(result);                    mockMvc.perform(...);   // cannot find symbol
        });                                              ctx.setMvcResult(...);  // cannot find symbol
    }                                                }
}                                                }
```

No `TODO Migrate manually` marker was emitted, so this was silent.

Each argument is now held in a field the constructor assigns, which is both what a hand migration does and what keeps the DI wiring intact:

```java
public class Steps {

    private final MockMvc mockMvc;
    private final Context ctx;

    public Steps(MockMvc mockMvc, Context ctx) {
        this.mockMvc = mockMvc;
        this.ctx = ctx;
    }

    @When("...")
    public void ...() throws Exception {
        mockMvc.perform(...);
        ctx.setMvcResult(result);
    }
}
```

- Classes whose constructor takes no arguments are unaffected, and that constructor is still removed as before. Left alone for now, as there is no single place to assign the fields from: classes declaring more than one constructor. Local variables declared in the constructor and captured by a hoisted lambda are the same bug class and are still open under #47.

Verified end to end against `Accenture/bdd-for-all` (cucumber 6.10.2, real DI glue): all five step definition classes now migrate with their fields and assignments intact, `implements En` removed, no lambdas left over, across both the step and the hook recipe.