### PR TITLE
Flag `TypeRegistryConfigurer` classes left for manual migration

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/TypeRegistryConfigurerToAnnotations.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/TypeRegistryConfigurerToAnnotations.java
@@ -18,6 +18,7 @@ package org.openrewrite.cucumber.jvm;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -28,6 +29,7 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.RemoveUnneededBlock;
 import org.openrewrite.staticanalysis.UnnecessaryThrows;
+import org.openrewrite.trait.Comments;
 
 import java.time.Duration;
 import java.util.*;
@@ -42,6 +44,9 @@ public class TypeRegistryConfigurerToAnnotations extends Recipe {
     private static final TypeMatcher TYPE_REGISTRY_CONFIGURER = new TypeMatcher("*..api.TypeRegistryConfigurer");
     private static final MethodMatcher CONFIGURE_TYPE_REGISTRY = new MethodMatcher(
             "*..api.TypeRegistryConfigurer configureTypeRegistry(*..api.TypeRegistry)", true);
+
+    private static final String MANUAL_MIGRATION = "TODO Cucumber-JVM 7.0.0 removed TypeRegistryConfigurer; " +
+            "migrate to @ParameterType, @DataTableType and @DocStringType annotated methods by hand";
 
     private static final String IO_CUCUMBER_JAVA_PARAMETER_TYPE = "io.cucumber.java.ParameterType";
     private static final String IO_CUCUMBER_JAVA_DATA_TABLE_TYPE = "io.cucumber.java.DataTableType";
@@ -89,7 +94,8 @@ public class TypeRegistryConfigurerToAnnotations extends Recipe {
 
     String description = "Cucumber-JVM 7.0.0 removed `TypeRegistryConfigurer`; replace implementations with " +
             "`@ParameterType`, `@DataTableType` and `@DocStringType` annotated glue methods. " +
-            "Classes whose `configureTypeRegistry` method cannot be converted in full are left untouched.";
+            "Classes whose `configureTypeRegistry` method cannot be converted in full are left untouched, " +
+            "with a `TODO` comment added above the registration that could not be converted.";
 
     Duration estimatedEffortPerOccurrence = Duration.ofMinutes(15);
 
@@ -114,7 +120,10 @@ public class TypeRegistryConfigurerToAnnotations extends Recipe {
                             }
                         }
                         if (configureTypeRegistry == null || configureTypeRegistry.getBody() == null) {
-                            return c;
+                            // No registration to comment, so flag the class; the blank line the class is
+                            // separated from the imports by would otherwise land between the two
+                            return Comments.of(new Cursor(getCursor().getParent(), c))
+                                    .comment(" " + MANUAL_MIGRATION, Comments.Placement.BEFORE, "\n");
                         }
 
                         Set<String> methodNames = new LinkedHashSet<>();
@@ -129,7 +138,7 @@ public class TypeRegistryConfigurerToAnnotations extends Recipe {
                             GlueMethod glueMethod = glueMethod(statement, methodNames);
                             if (glueMethod == null) {
                                 // Leave the whole class for manual migration rather than convert it halfway
-                                return c;
+                                return flagForManualMigration(c, configureTypeRegistry, statement);
                             }
                             glueMethods.add(glueMethod);
                         }
@@ -160,6 +169,37 @@ public class TypeRegistryConfigurerToAnnotations extends Recipe {
                         doAfterVisit(new RemoveUnneededBlock().getVisitor());
                         doAfterVisit(new UnnecessaryThrows().getVisitor());
                         return c;
+                    }
+
+                    /**
+                     * Comment the registration that blocked the conversion, rather than the class as a whole, as
+                     * that is the line to pick the manual migration up from. Left uncommented, the class silently
+                     * keeps a `TypeRegistryConfigurer` that no longer exists on the version being upgraded to.
+                     */
+                    private J.ClassDeclaration flagForManualMigration(J.ClassDeclaration c,
+                                                                      J.MethodDeclaration configureTypeRegistry,
+                                                                      Statement unconvertible) {
+                        J.Block configureTypeRegistryBody = configureTypeRegistry.getBody();
+                        if (configureTypeRegistryBody == null) {
+                            return c;
+                        }
+                        Cursor classCursor = new Cursor(getCursor().getParent(), c);
+                        Cursor bodyCursor = new Cursor(new Cursor(classCursor, c.getBody()), configureTypeRegistry);
+                        Statement commented = Comments
+                                .of(new Cursor(new Cursor(bodyCursor, configureTypeRegistryBody), unconvertible))
+                                .comment(" " + MANUAL_MIGRATION);
+                        if (commented == unconvertible) {
+                            // Already commented, on an earlier cycle
+                            return c;
+                        }
+                        return c.withBody(c.getBody().withStatements(ListUtils.map(c.getBody().getStatements(), s -> {
+                            if (s != configureTypeRegistry) {
+                                return s;
+                            }
+                            return configureTypeRegistry.withBody(configureTypeRegistryBody.withStatements(
+                                    ListUtils.map(configureTypeRegistryBody.getStatements(),
+                                            statement -> statement == unconvertible ? commented : statement)));
+                        })));
                     }
 
                     /**

--- a/src/test/java/org/openrewrite/cucumber/jvm/TypeRegistryConfigurerToAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/cucumber/jvm/TypeRegistryConfigurerToAnnotationsTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.cucumber.jvm;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -311,6 +312,126 @@ class TypeRegistryConfigurerToAnnotationsTest implements RewriteTest {
                   public void configureTypeRegistry(TypeRegistry typeRegistry) {
                       typeRegistry.defineParameterType(new ParameterType<>(
                               "author", "[A-Z][a-z]+", Author.class, TRANSFORMER));
+                  }
+              }
+              """,
+            """
+              package com.example.app;
+
+              import io.cucumber.core.api.TypeRegistry;
+              import io.cucumber.core.api.TypeRegistryConfigurer;
+              import io.cucumber.cucumberexpressions.ParameterType;
+              import io.cucumber.cucumberexpressions.Transformer;
+
+              import java.util.Locale;
+
+              public class ParameterTypeConfigurer implements TypeRegistryConfigurer {
+                  private static final Transformer<Author> TRANSFORMER = Author::new;
+
+                  @Override
+                  public Locale locale() {
+                      return Locale.ENGLISH;
+                  }
+
+                  @Override
+                  public void configureTypeRegistry(TypeRegistry typeRegistry) {
+                      // TODO Cucumber-JVM 7.0.0 removed TypeRegistryConfigurer; migrate to @ParameterType, @DataTableType and @DocStringType annotated methods by hand
+                      typeRegistry.defineParameterType(new ParameterType<>(
+                              "author", "[A-Z][a-z]+", Author.class, TRANSFORMER));
+                  }
+              }
+              """));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-cucumber-jvm/issues/47")
+    @Test
+    void flagOnlyTheRegistrationThatBlockedTheConversion() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example.app;
+
+              import io.cucumber.core.api.TypeRegistry;
+              import io.cucumber.core.api.TypeRegistryConfigurer;
+              import io.cucumber.datatable.DataTableType;
+
+              import java.util.Locale;
+              import java.util.Map;
+
+              public class AuthorConfigurer implements TypeRegistryConfigurer {
+                  @Override
+                  public Locale locale() {
+                      return Locale.ENGLISH;
+                  }
+
+                  @Override
+                  public void configureTypeRegistry(TypeRegistry typeRegistry) {
+                      typeRegistry.defineDataTableType(new DataTableType(Author.class,
+                              (Map<String, String> entry) -> new Author(entry.get("name"))));
+                      typeRegistry.setDefaultParameterTransformer((String fromValue, java.lang.reflect.Type toValueType) -> fromValue);
+                  }
+              }
+              """,
+            """
+              package com.example.app;
+
+              import io.cucumber.core.api.TypeRegistry;
+              import io.cucumber.core.api.TypeRegistryConfigurer;
+              import io.cucumber.datatable.DataTableType;
+
+              import java.util.Locale;
+              import java.util.Map;
+
+              public class AuthorConfigurer implements TypeRegistryConfigurer {
+                  @Override
+                  public Locale locale() {
+                      return Locale.ENGLISH;
+                  }
+
+                  @Override
+                  public void configureTypeRegistry(TypeRegistry typeRegistry) {
+                      typeRegistry.defineDataTableType(new DataTableType(Author.class,
+                              (Map<String, String> entry) -> new Author(entry.get("name"))));
+                      // TODO Cucumber-JVM 7.0.0 removed TypeRegistryConfigurer; migrate to @ParameterType, @DataTableType and @DocStringType annotated methods by hand
+                      typeRegistry.setDefaultParameterTransformer((String fromValue, java.lang.reflect.Type toValueType) -> fromValue);
+                  }
+              }
+              """));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-cucumber-jvm/issues/47")
+    @Test
+    void flagClassesThatDoNotDeclareConfigureTypeRegistry() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example.app;
+
+              import io.cucumber.core.api.TypeRegistryConfigurer;
+
+              import java.util.Locale;
+
+              public abstract class BaseConfigurer implements TypeRegistryConfigurer {
+                  @Override
+                  public Locale locale() {
+                      return Locale.ENGLISH;
+                  }
+              }
+              """,
+            """
+              package com.example.app;
+
+              import io.cucumber.core.api.TypeRegistryConfigurer;
+
+              import java.util.Locale;
+
+              // TODO Cucumber-JVM 7.0.0 removed TypeRegistryConfigurer; migrate to @ParameterType, @DataTableType and @DocStringType annotated methods by hand
+              public abstract class BaseConfigurer implements TypeRegistryConfigurer {
+                  @Override
+                  public Locale locale() {
+                      return Locale.ENGLISH;
                   }
               }
               """));


### PR DESCRIPTION
- Picks up the third box from #47.

`TypeRegistryConfigurerToAnnotations` converts a class only if every statement in `configureTypeRegistry` can be converted, and otherwise leaves it alone — deliberately, rather than migrating it halfway. The problem is that the bail left no trace at all, while the rest of `UpgradeCucumber7x` carried on: `CucumberApiToIoCucumber` has by then retyped `cucumber.api.TypeRegistryConfigurer` to `io.cucumber.core.api.TypeRegistryConfigurer`, which 7.0.0 removed, and `UpgradeDependencyVersion` has moved the project to 7.x. The result is a class that no longer compiles, with nothing pointing at why.

That is not a rare shape. Only the inline lambda form converts today; each of these is left behind:

| Shape | Converts |
| --- | --- |
| `defineDataTableType(new DataTableType(W.class, lambda))` | yes |
| transformer is a method reference (`W::new`) | no |
| transformer is an anonymous class (`new TableEntryTransformer<W>() {…}`) | no |
| any local variable statement in `configureTypeRegistry` | no |
| `setDefaultParameterTransformer` / `setDefaultDataTable*Transformer` present | no |
| 6-arg `ParameterType(name, regex, type, transformer, useForSnippets, preferForRegexMatch)` | no |
| registrations applied via `forEach(registry::defineDataTableType)` or a helper method | no |

- This adds a `TODO` comment, via the same `Comments` trait #44 uses, above the *registration* that blocked the conversion rather than on the class as a whole — that is the line to pick the manual migration up from:

```java
@Override
public void configureTypeRegistry(TypeRegistry typeRegistry) {
    typeRegistry.defineDataTableType(new DataTableType(Author.class,
            (Map<String, String> entry) -> new Author(entry.get("name"))));
    // TODO Cucumber-JVM 7.0.0 removed TypeRegistryConfigurer; migrate to @ParameterType, @DataTableType and @DocStringType annotated methods by hand
    typeRegistry.setDefaultParameterTransformer((String fromValue, java.lang.reflect.Type toValueType) -> fromValue);
}
```

Where there is no registration to point at — a class that implements the interface without declaring `configureTypeRegistry`, such as an abstract base — the comment goes on the class instead.

The trait is idempotent, so this converges rather than stacking a comment per cycle.

- Widening the conversion itself, so fewer classes need the comment at all, stays open under #47.

- Verified against the three repositories from #47 that hit this — `osvaldjr/easy-cucumber` (local variables plus `setDefault*Transformer`), `lanit-izh/automation-framework-box` and `CourseRepository/CucumberTutorial-io` — where the comment lands on the right statement and picks up the surrounding indentation, spaces or tabs.