### PR TITLE
Import `Scenario` in migrated hooks rather than qualify it

### DIFF
--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8ClassVisitor.java
@@ -40,7 +40,7 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
     private static final String IO_CUCUMBER_JAVA8 = "io.cucumber.java8";
 
     private final JavaType.FullyQualified stepDefinitionsClass;
-    private final String replacementImport;
+    private final List<String> replacementImports;
     private final String template;
     private final Object[] templateParameters;
 
@@ -56,8 +56,8 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
         // Remove implement of Java8 interfaces & imports; return retained
         List<TypeTree> retained = filterImplementingInterfaces(classDeclaration);
 
-        // Import Given/When/Then or Before/After as applicable
-        maybeAddImport(replacementImport);
+        // Import Given/When/Then or Before/After, and Scenario, as applicable
+        replacementImports.forEach(this::maybeAddImport);
 
         // Remove empty constructor which might be left over after removing
         // method invocations with typical usage
@@ -96,7 +96,7 @@ class CucumberJava8ClassVisitor extends JavaIsoVisitor<ExecutionContext> {
                 .contextSensitive()
                 .javaParser(
                         JavaParser.fromJavaVersion().classpathFromResources(ctx, "cucumber-java-7", "cucumber-java8-7"))
-                .imports(replacementImport)
+                .imports(replacementImports.toArray(new String[0]))
                 .build().apply(getCursor(), coordinatesForNewMethod(classDeclaration.getBody()), templateParameters);
         return retainConstructorArguments(applied.withImplements(retained));
     }

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8HookDefinitionToCucumberJava.java
@@ -32,7 +32,10 @@ import org.openrewrite.java.tree.JavaType.Primitive;
 import org.openrewrite.marker.SearchResult;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
+
+import static java.util.Collections.singletonList;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -91,7 +94,7 @@ public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
                                 .getValue();
                         doAfterVisit(new CucumberJava8ClassVisitor(
                                 parentClass.getType(),
-                                hookArguments.replacementImport(),
+                                hookArguments.replacementImports(),
                                 hookArguments.template(),
                                 hookArguments.parameters()));
 
@@ -140,6 +143,13 @@ public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
 @Value
 class HookArguments {
 
+    /**
+     * Imported as the `io.cucumber.java8` type the hook body still accepts, rather than as the
+     * `io.cucumber.java.Scenario` it will become: the file is only retyped once every hook and step in it has
+     * migrated, and until then the simple name has to resolve against the import already there.
+     */
+    private static final String IO_CUCUMBER_JAVA8_SCENARIO = "io.cucumber.java8.Scenario";
+
     String annotationName;
 
     @With
@@ -152,8 +162,11 @@ class HookArguments {
 
     J.Lambda lambda;
 
-    String replacementImport() {
-        return String.format("io.cucumber.java.%s", annotationName);
+    List<String> replacementImports() {
+        String annotationImport = String.format("io.cucumber.java.%s", annotationName);
+        return takesScenario() ?
+                Arrays.asList(annotationImport, IO_CUCUMBER_JAVA8_SCENARIO) :
+                singletonList(annotationImport);
     }
 
     String template() {
@@ -189,13 +202,16 @@ class HookArguments {
                 order == null ? "" : "_order_" + order);
     }
 
+    private boolean takesScenario() {
+        return lambda.getParameters().getParameters().get(0) instanceof J.VariableDeclarations;
+    }
+
     private String formatMethodArguments() {
-        J firstLambdaParameter = lambda.getParameters().getParameters().get(0);
-        if (firstLambdaParameter instanceof J.VariableDeclarations) {
-            return String.format("io.cucumber.java.Scenario %s",
-                    ((J.VariableDeclarations) firstLambdaParameter).getVariables().get(0).getName());
+        if (!takesScenario()) {
+            return "";
         }
-        return "";
+        J.VariableDeclarations scenario = (J.VariableDeclarations) lambda.getParameters().getParameters().get(0);
+        return String.format("Scenario %s", scenario.getVariables().get(0).getName());
     }
 
     public Object[] parameters() {

--- a/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/cucumber/jvm/CucumberJava8StepDefinitionToCucumberJava.java
@@ -33,6 +33,7 @@ import org.openrewrite.marker.SearchResult;
 import java.time.Duration;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 
 @EqualsAndHashCode(callSuper = false)
@@ -107,7 +108,7 @@ public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
                                 m.getSimpleName());
                         doAfterVisit(new CucumberJava8ClassVisitor(
                                 parentClass.getType(),
-                                replacementImport,
+                                singletonList(replacementImport),
                                 stepArguments.template(),
                                 stepArguments.parameters()));
 

--- a/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
+++ b/src/test/java/org/openrewrite/cucumber/jvm/CucumberJava8ToCucumberJavaTest.java
@@ -102,7 +102,7 @@ class CucumberJava8ToCucumberJavaTest implements RewriteTest {
                     }
 
                     @After
-                    public void after(io.cucumber.java.Scenario scn) {
+                    public void after(Scenario scn) {
                         if (scn.getStatus() == Status.FAILED) {
                             scn.log("failed");
                         }
@@ -671,24 +671,68 @@ class CucumberJava8ToCucumberJavaTest implements RewriteTest {
                         }
 
                         @Before(order = 2)
-                        public void before_order_2(io.cucumber.java.Scenario scn) {
+                        public void before_order_2(Scenario scn) {
                             a = 0;
                         }
 
                         @After
-                        public void after(io.cucumber.java.Scenario scn) {
+                        public void after(Scenario scn) {
                             if (scn.getStatus() == Status.FAILED) {
                                 scn.log("after scenario");
                             }
                         }
 
                         @After("abc")
-                        public void after_tag_abc(io.cucumber.java.Scenario scn) {
+                        public void after_tag_abc(Scenario scn) {
                             scn.log("after scenario");
                         }
 
                         @AfterStep
-                        public void afterStep(io.cucumber.java.Scenario scn) {
+                        public void afterStep(Scenario scn) {
+                            a = 0;
+                        }
+
+                    }
+                    """),
+                17));
+        }
+
+        @SuppressWarnings("CodeBlock2Expr")
+        @Test
+        void importScenarioWhereTheHookBodyLeavesItImplicit() {
+            rewriteRun(
+              version(
+                // language=java
+                java(
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java8.En;
+
+                    public class HookStepDefinitions implements En {
+
+                        private int a;
+
+                        public HookStepDefinitions() {
+                            After(scn -> {
+                                a = 0;
+                            });
+                        }
+
+                    }
+                    """,
+                  """
+                    package com.example.app;
+
+                    import io.cucumber.java.After;
+                    import io.cucumber.java.Scenario;
+
+                    public class HookStepDefinitions {
+
+                        private int a;
+
+                        @After
+                        public void after(Scenario scn) {
                             a = 0;
                         }
 


### PR DESCRIPTION
- Picks up the first of the three cosmetic items in #47.

The methods `CucumberJava8HookDefinitionToCucumberJava` generates for a hook body that accepts a `Scenario` spelled the parameter type out in full, next to an import of that very type:

```java
import io.cucumber.java.After;
import io.cucumber.java.Scenario;

@After
public void after(io.cucumber.java.Scenario scn) {
```

The parameter type now comes from the import, and `io.cucumber.java8.Scenario` is added as an import where the hook body left the parameter type implicit (`After(scn -> …)`) and the file therefore had no import to lean on:

```java
@After
public void after(Scenario scn) {
```

- Imported as the `io.cucumber.java8` type rather than as the `io.cucumber.java.Scenario` it ends up as, deliberately. The template is applied while the file is still mid-migration: `CucumberJava8ToJava` only retypes `io.cucumber.java8` → `io.cucumber.java` after every hook and step in the file has been converted, so until then the simple name has to resolve against the `io.cucumber.java8.Scenario` import the file already carries. Importing the `io.cucumber.java` name instead puts two `Scenario` imports in scope, and the parameter comes out with no type attached at all. It also means running this recipe on its own, without the package change, now leaves a file that still compiles against `cucumber-java8`.

### The other two items in 7 are not fixed here

Both turn out to be behaviours of the underlying `rewrite-java` recipes rather than of anything this repository controls, and every workaround I tried costs more than the wart:

- **Import order.** `ChangePackage` renames imports where they stand rather than reinserting them in order, so `io.cucumber.java8.Scenario` keeps the slot it held when it sorted after `io.cucumber.java.en.When`. Sorting afterwards means running `OrderImports` over the migrated file, which with the default style also folds the five-plus `io.cucumber.java` imports of a typical glue class into `import io.cucumber.java.*`, and pinning a star-import threshold to prevent that means shipping a full `ImportLayoutStyle` that overrides whatever layout the project actually uses. Doing the retyping inside `CucumberJava8ClassVisitor` instead, early enough to sort with, retypes `io.cucumber.java8.En` mid-cycle and stops `CucumberJava8StepDefinitionToCucumberJava` from matching the very steps it was about to migrate.

  The clean fix is to stop feeding `ChangePackage` types that have to move at all: `Scenario` and `Status` are the only `io.cucumber.java8` types that exist under `io.cucumber.java`, and `ChangeType` reinserts imports in order. That is the same change item 5 needs — retyping `En`, `HookBody` and friends onto names that do not exist is what breaks unconverted classes — so it belongs there, not here.

- **The unused `CucumberOptions.SnippetType` import.** `ChangeType`, given a nested target, writes the reference through its outer class and imports *both* the outer class and the nested type ([`ChangeType.java#L268-L279`](https://github.com/openrewrite/rewrite/blob/main/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java)), leaving the second import redundant:

  ```java
  import io.cucumber.junit.CucumberOptions;
  import io.cucumber.junit.CucumberOptions.SnippetType;   // unused

  @CucumberOptions(snippets = CucumberOptions.SnippetType.CAMELCASE)
  ```

  `RemoveUnusedImports` keeps it, since the type *is* referenced; `ShortenFullyQualifiedTypeReferences` leaves `CucumberOptions.SnippetType` alone, since it is not package qualified; and writing the target with dots instead of `$` gets the reference right but drops the import entirely, which does not compile. Fixing it properly means either `ChangeType` emitting the simple name when it has imported the nested type, or a general recipe that shortens an imported nested type — either way in `rewrite-java`, not here. Happy to raise it upstream.

Full test suite green, with a new test covering the implicit-parameter hook.
